### PR TITLE
Translated the index warnings / errors / Field is an object

### DIFF
--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -482,7 +482,7 @@
     </xsl:for-each>
 
     <xsl:for-each select="$allKeywords//indexingErrorMsg">
-      <indexingErrorMsg><xsl:value-of select="."/></indexingErrorMsg>
+      <indexingErrorMsg type="object"><xsl:copy-of select="*"/></indexingErrorMsg>
     </xsl:for-each>
   </xsl:template>
 


### PR DESCRIPTION
@joachimnielandt I fixed one error I had when keyword is not found

```
Document with error #7fe2f305-1302-4297-b67e-792f55acd834: ElasticsearchException[Elasticsearch exception [type=mapper_parsing_exception, reason=object mapping for [indexingErrorMsg] tried to parse field [null] as object, but found a concrete value]].
```